### PR TITLE
Get makefile to work on Mac

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,8 +1,8 @@
 SETUP=setup.py
 
-MODULE=$(shell sed -n "s@^.*name='\([^']\+\)'.*@\L\1@p" "$(SETUP)")
-AUTHOR=$(shell sed -n "s@^.*author='\([^']\+\)'.*@\1@p" "$(SETUP)")
-VERSION=$(shell sed -n "s@^.*version='\([^']\+\)'.*@\1@p" "$(SETUP)")
+MODULE=$(shell sed -n "s/.*name='\(.*\)',/\1/p" "$(SETUP)" | tr '[:upper:]' '[:lower:]')
+AUTHOR=$(shell sed -n "s/.*author='\(.*\)',/\1/p" "$(SETUP)")
+VERSION=$(shell sed -n "s/.*version='\(.*\)',/\1/p" "$(SETUP)")
 
 SRC_DIR=$(MODULE)
 DOC_DIR=docs


### PR DESCRIPTION
Right now, the make file relies on the environment having the GNU tools as part of the shell (available by default on some Linux distros such as Mint). However, Mac doesn't have this by default causing each sed to return empty, so need to use more basic sed syntax in addition to tr to follow POSIX specification and allow greater compatibility with systems.

Tested on:
Linux Mint 17 (qiana) - Kernel: 3.13.0-24 - GNOME: 3.84
Mac OSX 10.10

All commands utilizing the strings work as expected (otherwise)
