### PR TITLE
Added support for downloading texts from more languages

### DIFF
--- a/gutenberg/acquire/text.py
+++ b/gutenberg/acquire/text.py
@@ -42,7 +42,7 @@ def _format_download_uri(etextno):
 
     else:
         etextno = str(etextno)
-        extensions = ('.txt', '-8.txt')
+        extensions = ('.txt', '-8.txt', '-0.txt')
         for extension in extensions:
             uri = '{root}/{path}/{etextno}/{etextno}{extension}'.format(
                 root=uri_root,
@@ -70,6 +70,7 @@ def load_etext(etextno, refresh_cache=False):
         makedirs(os.path.dirname(cached))
         download_uri = _format_download_uri(etextno)
         response = requests.get(download_uri)
+        response.encoding = 'utf-8'
         text = response.text
         with gzip.open(cached, 'w') as cache:
             cache.write(text.encode('utf-8'))

--- a/tests/data/sample-metadata/23962
+++ b/tests/data/sample-metadata/23962
@@ -1,0 +1,4 @@
+{
+    "authors": ["Cheng'en Wu"],
+    "titles": ["西遊記"]
+}

--- a/tests/test_acquire.py
+++ b/tests/test_acquire.py
@@ -36,6 +36,7 @@ class TestLoadEtext(MockTextMixin, unittest.TestCase):
             SampleMetaData.for_etextno(2701),   # newstyle identifier
             SampleMetaData.for_etextno(5),      # oldstyle identifier
             SampleMetaData.for_etextno(14287),  # unicode text
+            SampleMetaData.for_etextno(23962)   # UTF-8 text
         )
         for testcase, loader in itertools.product(testcases, loaders):
             text = loader(testcase.etextno)


### PR DESCRIPTION
The current version uses ISO-8859-1 as the encoding to download Gutenberg ebooks. However this restricts the languages that this library can download ([see here](http://en.wikipedia.org/wiki/ISO/IEC_8859-1#Languages_with_complete_coverage)).

For example, the current version cannot download Chinese texts. The changes I have made fixes that by changing the `requests.get` encoding to `utf-8`. Below is a script that downloads [Journey to the West](http://www.gutenberg.org/ebooks/23962), a Chinese ebook, and saves it using the appropriate encoding.

```
from gutenberg.acquire import load_etext
from gutenberg.cleanup import strip_headers

OUTFILE = "<insert outfile destination here>"
text = strip_headers(load_etext(23962)).strip()
with open(OUTFILE, 'w') as f:
    f.write(text)
```