### PR TITLE
Make it explicit what metadata is available

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,8 @@ Downloading a text
 Looking up meta-data
 --------------------
 
+Title and author meta-data can queried:
+
 .. sourcecode :: python
 
     from gutenberg.query import get_etexts


### PR DESCRIPTION
I know someone who was a bit surprised there was only title and author metadata available after leaving it to run overnight building the database.

So perhaps it should be made a bit clearer that there's only title and author available. Perhaps something like this?