### PR TITLE
Include requirements.pip in the sdist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,4 +16,5 @@ setup(
     license='LICENSE.txt',
     description='Library to interface with Project Gutenberg',
     long_description=open('README.rst').read(),
+    data_files=[('', ['requirements.pip'])],
     install_requires=list(line.strip() for line in open('requirements.pip')))


### PR DESCRIPTION
requirements.pip isn't being included in the final sdist package resulting in failures during pip install. Noticed this when trying to install from PyPi:

~~~
# pip install gutenberg
Collecting gutenberg
  Using cached Gutenberg-0.4.1.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-SUHROb/gutenberg/setup.py", line 19, in <module>
        install_requires=list(line.strip() for line in open('requirements.pip')))

    IOError: [Errno 2] No such file or directory: 'requirements.pip'
~~~

This fixes that. The PyPi package will need to be updated.