### PR TITLE
Add an extractor to return a list of eBook URIs

### DIFF
--- a/gutenberg/query/extractors.py
+++ b/gutenberg/query/extractors.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 
 from rdflib.term import Literal
+from rdflib.term import URIRef
 
 from gutenberg._domain_model.vocabulary import DCTERMS
 from gutenberg._domain_model.vocabulary import PGTERMS
@@ -32,7 +33,7 @@ class _SimplePredicateRelationshipExtractor(MetadataExtractor):
 
     @classmethod
     def get_etexts(cls, requested_value):
-        query = cls._metadata()[:cls.predicate():Literal(requested_value)]
+        query = cls._metadata()[:cls.predicate():cls.contains(requested_value)]
         return frozenset(cls._uri_to_etext(result) for result in query)
 
 
@@ -48,6 +49,10 @@ class AuthorExtractor(_SimplePredicateRelationshipExtractor):
     def predicate(cls):
         return DCTERMS.creator / PGTERMS.alias
 
+    @classmethod
+    def contains(cls, value):
+        return Literal(value)
+
 
 class TitleExtractor(_SimplePredicateRelationshipExtractor):
     """Extracts book titles.
@@ -61,6 +66,10 @@ class TitleExtractor(_SimplePredicateRelationshipExtractor):
     def predicate(cls):
         return DCTERMS.title
 
+    @classmethod
+    def contains(cls, value):
+        return Literal(value)
+
 
 class FormatURIExtractor(_SimplePredicateRelationshipExtractor):
     """Extracts book format URIs.
@@ -73,3 +82,7 @@ class FormatURIExtractor(_SimplePredicateRelationshipExtractor):
     @classmethod
     def predicate(cls):
         return DCTERMS.hasFormat
+
+    @classmethod
+    def contains(cls, value):
+        return URIRef(value)

--- a/gutenberg/query/extractors.py
+++ b/gutenberg/query/extractors.py
@@ -60,3 +60,16 @@ class TitleExtractor(_SimplePredicateRelationshipExtractor):
     @classmethod
     def predicate(cls):
         return DCTERMS.title
+
+
+class FormatURIExtractor(_SimplePredicateRelationshipExtractor):
+    """Extracts book format URIs.
+
+    """
+    @classmethod
+    def feature_name(cls):
+        return 'formaturi'
+
+    @classmethod
+    def predicate(cls):
+        return DCTERMS.hasFormat

--- a/tests/_sample_metadata.py
+++ b/tests/_sample_metadata.py
@@ -14,9 +14,11 @@ from six import u
 class SampleMetaData(object):
     __uids = {}
 
-    def __init__(self, etextno, authors=frozenset(), titles=frozenset()):
+    def __init__(self, etextno, authors=frozenset(), titles=frozenset(),
+            formaturi=frozenset()):
         self.author = frozenset(authors)
         self.title = frozenset(titles)
+        self.formaturi = frozenset(formaturi)
         self.etextno = etextno or self.__create_uid(self.author | self.title)
 
     @classmethod
@@ -54,11 +56,21 @@ class SampleMetaData(object):
             .format(etextno=self.etextno, title=title)
             for title in self.title)
 
+    def _rdf_formaturi(self):
+        return u('') if not self.formaturi else u('\n').join(
+            u('<http://www.gutenberg.org/ebooks/{etextno}> '
+              '<http://purl.org/dc/terms/hasFormat> '
+              '<{formaturi}>'
+              '.')
+            .format(etextno=self.etextno, formaturi=formaturi)
+            for formaturi in self.formaturi)
+
     def rdf(self):
         return u('\n').join(fact for fact in (
             self._rdf_etextno(),
             self._rdf_author(),
             self._rdf_title(),
+            self._rdf_formaturi(),
         ) if fact)
 
     @classmethod

--- a/tests/data/sample-metadata/30929
+++ b/tests/data/sample-metadata/30929
@@ -1,4 +1,15 @@
 {
     "authors": ["Verne, Jules Gabriël"],
-    "titles": ["Het loterijbriefje"]
+    "titles": ["Het loterijbriefje"],
+    "formaturi": [ "http://www.gutenberg.org/ebooks/30929.epub.noimages",
+        "http://www.gutenberg.org/ebooks/30929.kindle.images",
+        "http://www.gutenberg.org/files/30929/30929-8.txt",
+        "http://www.gutenberg.org/files/30929/30929-h.zip",
+        "http://www.gutenberg.org/ebooks/30929.rdf",
+        "http://www.gutenberg.org/ebooks/30929.kindle.noimages",
+        "http://www.gutenberg.org/files/30929/30929-h/30929-h.htm",
+        "http://www.gutenberg.org/ebooks/30929.epub.images",
+        "http://www.gutenberg.org/files/30929/30929-8.zip",
+        "http://www.gutenberg.org/ebooks/30929.txt.utf-8"
+    ]
 }

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -38,6 +38,8 @@ class TestGetMetadata(MockMetadataMixin, unittest.TestCase):
     def test_get_metadata_author(self):
         self._run_get_metadata_for_feature('author')
 
+    def test_get_metadata_formaturi(self):
+        self._run_get_metadata_for_feature('formaturi')
 
 class TestGetEtexts(MockMetadataMixin, unittest.TestCase):
     def sample_data(self):
@@ -62,6 +64,9 @@ class TestGetEtexts(MockMetadataMixin, unittest.TestCase):
 
     def test_get_etexts_author(self):
         self._run_get_etexts_for_feature('author')
+
+    def test_get_etexts_formaturi(self):
+        self._run_get_etexts_for_feature('formaturi')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I need to be able to return all available URIs for an ebook, specified by the hasFormat predicate in the RDF graph. This does that.

~~~
vagrant@ol-dev:/openlibrary/Gutenberg$ python -c "from gutenberg.query import get_metadata; print(get_metadata('formaturi', 2701))"
INFO:rdflib:RDFLib Version: 4.2.1
frozenset([u'http://www.gutenberg.org/files/2701/2701.txt',
u'http://www.gutenberg.org/files/2701/2701.zip',
u'http://www.gutenberg.org/ebooks/2701.rdf',
u'http://www.gutenberg.org/ebooks/2701.kindle.images',
u'http://www.gutenberg.org/ebooks/2701.epub.images', 
u'http://www.gutenberg.org/ebooks/2701.epub.noimages', 
u'http://www.gutenberg.org/files/2701/2701-h/2701-h.htm', 
u'http://www.gutenberg.org/ebooks/2701.kindle.noimages', 
u'http://www.gutenberg.org/files/2701/2701-h.zip', 
u'http://www.gutenberg.org/ebooks/2701.txt.utf-8'])
~~~