### PR TITLE
fix broken dependency for SQLAlchemy on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
   - sudo apt-get install -qq -y libdb5.1-dev
 
 install:
+  - pip install -U setuptools
   - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install unittest2; fi
   - pip install -r requirements.pip
   - pip install -r requirements-py3.pip

--- a/requirements.pip
+++ b/requirements.pip
@@ -2,4 +2,5 @@ future>=0.15.2
 rdflib>=4.2.0
 requests>=2.5.1
 six>=1.10.0
+setuptools>=18.5
 git+https://github.com/RDFLib/rdflib-sqlalchemy.git@20fbf1fbbdbc53917bfd7554f38d22d08e71e225


### PR DESCRIPTION
html5lib requires setuptools version 18.5 or above; please upgrade before installing (you have 12.0.5)

This does leave Python 3.2 still broken, but that's for a completely different reason.