### PR TITLE
Additional RDF metadata extractors for language, subject(s), and copyright

### DIFF
--- a/gutenberg/_domain_model/vocabulary.py
+++ b/gutenberg/_domain_model/vocabulary.py
@@ -9,3 +9,4 @@ import rdflib.namespace
 
 DCTERMS = rdflib.namespace.DCTERMS
 PGTERMS = rdflib.namespace.Namespace(r'http://www.gutenberg.org/2009/pgterms/')
+RDFTERMS = rdflib.namespace.RDF

--- a/gutenberg/query/api.py
+++ b/gutenberg/query/api.py
@@ -8,6 +8,7 @@ import os
 
 from six import with_metaclass
 from rdflib.term import URIRef
+from rdflib.term import bind
 
 from gutenberg._domain_model.exceptions import UnsupportedFeatureException
 from gutenberg._domain_model.types import validate_etextno
@@ -15,6 +16,14 @@ from gutenberg._util.abc import abstractclassmethod
 from gutenberg._util.objects import all_subclasses
 from gutenberg.acquire.metadata import load_metadata
 
+import sys
+
+
+# Add a binding for Project Gutenberg's Language datatype
+if sys.version_info < (3,):
+    bind(URIRef('http://purl.org/dc/terms/RFC4646'), unicode)
+else:
+    bind(URIRef('http://purl.org/dc/terms/RFC4646'), str)
 
 def get_metadata(feature_name, etextno):
     """Looks up the value of a meta-data feature for a given text.

--- a/gutenberg/query/extractors.py
+++ b/gutenberg/query/extractors.py
@@ -8,6 +8,7 @@ from rdflib.term import URIRef
 
 from gutenberg._domain_model.vocabulary import DCTERMS
 from gutenberg._domain_model.vocabulary import PGTERMS
+from gutenberg._domain_model.vocabulary import RDFTERMS
 from gutenberg._util.abc import abstractclassmethod
 from gutenberg.query.api import MetadataExtractor
 
@@ -86,3 +87,36 @@ class FormatURIExtractor(_SimplePredicateRelationshipExtractor):
     @classmethod
     def contains(cls, value):
         return URIRef(value)
+
+class RightsExtractor(_SimplePredicateRelationshipExtractor):
+    """Extracts the copyright information.
+
+    """
+    @classmethod
+    def feature_name(cls):
+        return 'rights'
+
+    @classmethod
+    def predicate(cls):
+        return DCTERMS.rights
+
+    @classmethod
+    def contains(cls, value):
+        return Literal(value)
+
+
+class SubjectExtractor(_SimplePredicateRelationshipExtractor):
+    """Extracts the subject(s).
+
+    """
+    @classmethod
+    def feature_name(cls):
+        return 'subject'
+
+    @classmethod
+    def predicate(cls):
+        return DCTERMS.subject / RDFTERMS.value
+
+    @classmethod
+    def contains(cls, value):
+        return Literal(value)

--- a/gutenberg/query/extractors.py
+++ b/gutenberg/query/extractors.py
@@ -104,6 +104,21 @@ class RightsExtractor(_SimplePredicateRelationshipExtractor):
     def contains(cls, value):
         return Literal(value)
 
+class LanguageExtractor(_SimplePredicateRelationshipExtractor):
+    """Extracts the language.
+
+    """
+    @classmethod
+    def feature_name(cls):
+        return 'language'
+
+    @classmethod
+    def predicate(cls):
+        return DCTERMS.language / RDFTERMS.value
+
+    @classmethod
+    def contains(cls, value):
+        return Literal(value)
 
 class SubjectExtractor(_SimplePredicateRelationshipExtractor):
     """Extracts the subject(s).

--- a/tests/_sample_metadata.py
+++ b/tests/_sample_metadata.py
@@ -14,11 +14,15 @@ from six import u
 class SampleMetaData(object):
     __uids = {}
 
-    def __init__(self, etextno, authors=None, titles=None, formaturi=None):
+    def __init__(self, etextno, authors=None, titles=None, formaturi=None, rights=None, subject=None, language=None):
         self.author = frozenset(authors or [])
         self.title = frozenset(titles or [])
         self.formaturi = frozenset(formaturi or [])
         self.etextno = etextno or self.__create_uid(self.author | self.title)
+        self.rights = frozenset(rights or [])
+        self.subject = frozenset(subject or [])
+        self.language = frozenset(language or [])
+
 
     @classmethod
     def __create_uid(cls, hashable):
@@ -54,6 +58,34 @@ class SampleMetaData(object):
               '.')
             .format(etextno=self.etextno, title=title)
             for title in self.title)
+
+    def _rdf_rights(self):
+        return u('') if not self.rights else u('\n').join(
+            u('<http://www.gutenberg.org/ebooks/{etextno}> '
+              '<http://purl.org/dc/terms/rights> '
+              '"{rights}"'
+              '.')
+            .format(etextno=self.etextno, rights=rights)
+            for rights in self.rights)
+
+    def _rdf_subject(self):
+        return u('') if not self.subject else u('\n').join(
+            u('<http://www.gutenberg.org/ebooks/{etextno}> '
+              '<http://www.w3.org/1999/02/22-rdf-syntax-ns#Description>'
+              '"{subject}"'
+              '.')
+            .format(etextno=self.etextno, subject=subject)
+            for subject in self.subject)
+
+    def _rdf_language(self):
+        return u('') if not self.language else u('\n').join(
+            u('<http://www.gutenberg.org/ebooks/{etextno}> '
+              '<http://purl.org/dc/terms/language> '
+              '<http://www.w3.org/1999/02/22-rdf-syntax-ns#Description>'
+              '"{language}"'
+              '.')
+            .format(etextno=self.etextno, language=language)
+            for subject in self.language)
 
     def _rdf_formaturi(self):
         return u('') if not self.formaturi else u('\n').join(

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -41,6 +41,14 @@ class TestGetMetadata(MockMetadataMixin, unittest.TestCase):
     def test_get_metadata_formaturi(self):
         self._run_get_metadata_for_feature('formaturi')
 
+    def test_get_metadata_rights(self):
+        self._run_get_metadata_for_feature('rights')
+
+    def test_get_metadata_subject(self):
+        self._run_get_metadata_for_feature('subject')
+
+    def test_get_metadata_language(self):
+        self._run_get_metadata_for_feature('language')
 
 class TestGetEtexts(MockMetadataMixin, unittest.TestCase):
     def sample_data(self):
@@ -69,6 +77,14 @@ class TestGetEtexts(MockMetadataMixin, unittest.TestCase):
     def test_get_etexts_formaturi(self):
         self._run_get_etexts_for_feature('formaturi')
 
+    def test_get_etexts_language(self):
+        self._run_get_etexts_for_feature('language')
+
+    def test_get_etexts_rights(self):
+        self._run_get_etexts_for_feature('rights')
+
+    def test_get_etexts_subject(self):
+        self._run_get_etexts_for_feature('subject')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I've added extractors for more metadata information. As an example, here's the results for Moby Dick:
````
get_metadata('title', 2701) : frozenset({'Moby Dick; Or, The Whale'})
get_metadata('author', 2701) : frozenset({'Melville, Hermann'})
get_metadata('rights', 2701) : frozenset({'Public domain in the USA.'})
get_metadata('subject', 2701) : frozenset({'Adventure stories', 'Sea stories', 'Whales -- Fiction', 'Psychological fiction', 'Whaling ships -- Fiction', 'Ahab, Captain (Fictitious character) -- Fiction', 'Whaling -- Fiction', 'Mentally ill -- Fiction', 'Ship captains -- Fiction', 'PS'})
get_metadata('language', 2701) : frozenset({rdflib.term.Literal('en', datatype=rdflib.term.URIRef('http://purl.org/dc/terms/RFC4646'))})
````