### PR TITLE
Support Python 3.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ The functionality provided by this package includes:
 * Cleaning the texts: removing all the crud, leaving just the text behind.
 * Making meta-data about the texts easily accessible.
 
-The package has been tested with Python 2.6, 2.7 and 3.4
+The package has been tested with Python 2.6, 2.7, 3.2, 3.3, 3.4 and 3.5.
 
 
 Installation

--- a/requirements.pip
+++ b/requirements.pip
@@ -1,6 +1,6 @@
 future>=0.15.2
 rdflib>=4.2.0
-requests>=2.5.1
+requests>=2.5.1,<2.11.0
 six>=1.10.0
 setuptools>=18.5
 git+https://github.com/RDFLib/rdflib-sqlalchemy.git@20fbf1fbbdbc53917bfd7554f38d22d08e71e225


### PR DESCRIPTION
Closes https://github.com/c-w/Gutenberg/issues/49.

The build fails because requests no longer supports Python 3.2.

If 3.2 is still desired for this project:
- then pin the required requests version to the last one that supports 3.2.
- this PR could be improved by only pinning the requests version on Python 3.2, and allowing other Pythons to use the most recent.

But see also PR https://github.com/c-w/Gutenberg/pull/53 that removes support for 3.2.
