### PR TITLE
Update tests

### DIFF
--- a/tests/_util.py
+++ b/tests/_util.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 
 import abc
 import shutil
+import sys
 import tempfile
 from contextlib import closing
 from contextlib import contextmanager
@@ -18,6 +19,12 @@ from six import with_metaclass
 from gutenberg.acquire.metadata import SleepycatMetadataCache
 from gutenberg.acquire.metadata import set_metadata_cache
 import gutenberg.acquire.text
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+assert unittest  # silence warning
 
 
 # noinspection PyPep8Naming,PyAttributeOutsideInit

--- a/tests/test_acquire.py
+++ b/tests/test_acquire.py
@@ -6,13 +6,13 @@
 from __future__ import absolute_import
 from builtins import str
 import itertools
-import unittest
 
 from gutenberg._domain_model.vocabulary import DCTERMS
 from gutenberg._domain_model.vocabulary import PGTERMS
 from tests._sample_metadata import SampleMetaData
 from tests._util import MockMetadataMixin
 from tests._util import MockTextMixin
+from tests._util import unittest
 
 from gutenberg.acquire import load_etext
 from gutenberg.acquire import load_metadata

--- a/tests/test_acquire.py
+++ b/tests/test_acquire.py
@@ -24,9 +24,9 @@ class TestLoadMetadata(MockMetadataMixin, unittest.TestCase):
 
     def test_load_metadata(self):
         metadata = load_metadata()
-        self.assertTrue(len(list(metadata[::PGTERMS.ebook])) > 0)
-        self.assertTrue(len(list(metadata[:DCTERMS.creator:])) > 0)
-        self.assertTrue(len(list(metadata[:DCTERMS.title:])) > 0)
+        self.assertGreater(len(list(metadata[::PGTERMS.ebook])), 0)
+        self.assertGreater(len(list(metadata[:DCTERMS.creator:])), 0)
+        self.assertGreater(len(list(metadata[:DCTERMS.title:])), 0)
 
 
 class TestLoadEtext(MockTextMixin, unittest.TestCase):
@@ -41,7 +41,7 @@ class TestLoadEtext(MockTextMixin, unittest.TestCase):
         )
         for testcase, loader in itertools.product(testcases, loaders):
             text = loader(testcase.etextno)
-            self.assertTrue(isinstance(text, str))
+            self.assertIsInstance(text, str)
 
 
 if __name__ == '__main__':

--- a/tests/test_domain_model.py
+++ b/tests/test_domain_model.py
@@ -3,10 +3,10 @@
 
 
 from __future__ import absolute_import
-import unittest
 
 from gutenberg._domain_model.exceptions import InvalidEtextIdException
 from gutenberg._domain_model.types import validate_etextno
+from tests._util import unittest
 
 
 class TestValidateEtextno(unittest.TestCase):

--- a/tests/test_domain_model.py
+++ b/tests/test_domain_model.py
@@ -11,10 +11,10 @@ from gutenberg._domain_model.types import validate_etextno
 
 class TestValidateEtextno(unittest.TestCase):
     def test_is_valid_etext(self):
-        self.assertTrue(validate_etextno(1) is not None)
-        self.assertTrue(validate_etextno(12) is not None)
-        self.assertTrue(validate_etextno(123) is not None)
-        self.assertTrue(validate_etextno(1234) is not None)
+        self.assertIsNotNone(validate_etextno(1))
+        self.assertIsNotNone(validate_etextno(12))
+        self.assertIsNotNone(validate_etextno(123))
+        self.assertIsNotNone(validate_etextno(1234))
 
     def test_is_invalid_etext(self):
         self.assertRaises(InvalidEtextIdException, validate_etextno, 'not-int')

--- a/tests/test_metadata_cache.py
+++ b/tests/test_metadata_cache.py
@@ -17,11 +17,7 @@ from gutenberg.acquire.metadata import SleepycatMetadataCache
 from gutenberg.acquire.metadata import SqliteMetadataCache
 from gutenberg.acquire.metadata import set_metadata_cache
 from gutenberg.query import get_metadata
-
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+from tests._util import unittest
 
 
 # noinspection PyPep8Naming,PyAttributeOutsideInit

--- a/tests/test_metadata_cache.py
+++ b/tests/test_metadata_cache.py
@@ -43,7 +43,7 @@ class MetadataCache(object):
         self.cache.populate()
         set_metadata_cache(self.cache)
         title = get_metadata('title', 30929)
-        self.assertTrue(u('Het loterijbriefje') in title)
+        self.assertIn(u('Het loterijbriefje'), title)
 
     def test_repopulate(self):
         self.cache.populate()
@@ -51,17 +51,17 @@ class MetadataCache(object):
         self.cache.delete()
         self.cache.populate()
         title = get_metadata('title', 30929)
-        self.assertTrue(u('Het loterijbriefje') in title)
+        self.assertIn(u('Het loterijbriefje'), title)
 
     def test_refresh(self):
         self.cache.populate()
         set_metadata_cache(self.cache)
         title = get_metadata('title', 30929)
-        self.assertTrue(u('Het loterijbriefje') in title)
+        self.assertIn(u('Het loterijbriefje'), title)
 
         self.cache.refresh()
         title = get_metadata('title', 30929)
-        self.assertTrue(u('Het loterijbriefje') in title)
+        self.assertIn(u('Het loterijbriefje'), title)
 
     def test_repopulate_without_delete(self):
         # Trying to populate an existing cache should raise an exception

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -3,7 +3,6 @@
 
 
 from __future__ import absolute_import
-import unittest
 
 from six import u
 
@@ -12,6 +11,7 @@ from tests._util import MockMetadataMixin
 
 from gutenberg.query import get_etexts
 from gutenberg.query import get_metadata
+from tests._util import unittest
 
 
 class TestGetMetadata(MockMetadataMixin, unittest.TestCase):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -22,8 +22,9 @@ class TestGetMetadata(MockMetadataMixin, unittest.TestCase):
         for testcase in self.sample_data():
             expected = getattr(testcase, feature)
             actual = get_metadata(feature, testcase.etextno)
-            self.assertTrue(
-                set(actual) == set(expected),
+            self.assertEqual(
+                set(actual),
+                set(expected),
                 u('non-matching {feature} for book {etextno}: '
                   'expected={expected} actual={actual}')
                 .format(
@@ -58,8 +59,9 @@ class TestGetEtexts(MockMetadataMixin, unittest.TestCase):
         for testcase in self.sample_data():
             for feature_value in getattr(testcase, feature):
                 actual = get_etexts(feature, feature_value)
-                self.assertTrue(
-                    testcase.etextno in actual,
+                self.assertIn(
+                    testcase.etextno,
+                    actual,
                     u("didn't retrieve {etextno} when querying for books that "
                       'have {feature}="{feature_value}" (got {actual}).')
                     .format(

--- a/tests/test_strip_headers.py
+++ b/tests/test_strip_headers.py
@@ -3,11 +3,11 @@
 
 
 from __future__ import absolute_import
-import unittest
 
 from six import u
 
 from tests._sample_text import SampleText
+from tests._util import unittest
 
 from gutenberg.cleanup import strip_headers
 

--- a/tests/test_strip_headers.py
+++ b/tests/test_strip_headers.py
@@ -19,8 +19,9 @@ class TestStripHeaders(unittest.TestCase):
             actual = strip_headers(testcase.raw_text).splitlines()
             lines = list(zip(actual, expected))
             for i, (actual_line, expected_line) in enumerate(lines, start=1):
-                self.assertTrue(
-                    actual_line == expected_line,
+                self.assertEqual(
+                    actual_line,
+                    expected_line,
                     u('non-matching lines for etext {etextno}:\n'
                       '{previous_lines}\n'
                       '{lineno_separator}\n'

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,7 +8,6 @@ import abc
 import os
 import shutil
 import tempfile
-import unittest
 
 from six import with_metaclass
 
@@ -16,6 +15,7 @@ from gutenberg._util.abc import abstractclassmethod
 from gutenberg._util.objects import all_subclasses
 from gutenberg._util.os import makedirs
 from gutenberg._util.os import remove
+from tests._util import unittest
 
 
 class TestAllSubclasses(unittest.TestCase):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -39,7 +39,7 @@ class TestAllSubclasses(unittest.TestCase):
             pass
 
         self.assertTrue(all_subclasses(Root), set([AB, ABC, AD, ABAD, ABADE]))
-        self.assertTrue(all_subclasses(ABADE) == set())
+        self.assertEqual(all_subclasses(ABADE), set())
 
 
 class TestAbstractClassMethod(unittest.TestCase):


### PR DESCRIPTION
Most of the tests use `self.assertTrue`.

However, there are other [assert methods](https://docs.python.org/2/library/unittest.html#assert-methods) like `assertGreater` and `assertIn` which will give more descriptive error messages on failure than `assertTrue`.
