### PR TITLE
Run tests with coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+# .coveragerc to control coverage.py
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma:
+    pragma: no cover
+
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == .__main__.:
+    def _main()

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /dist/
 /*.egg-info
 /.idea/
+.coverage

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /*.egg-info
 /.idea/
 .coverage
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,13 @@ install:
   - pip install -r requirements.pip
   - pip install -r requirements-py3.pip
 
-script: nosetests
+  # Coverage 4.0 doesn't support Python 3.2
+  - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then travis_retry pip install coverage==3.7.1; fi
+  - if [ "$TRAVIS_PYTHON_VERSION" != "3.2" ]; then travis_retry pip install coverage; fi
+
+script: coverage run --source=gutenberg -m nose
+
+after_success:
+  - coverage report
+  - pip install coveralls
+  - coveralls


### PR DESCRIPTION
This uses the Coverage.py tool to measure the coverage of the unit tests.

Coverage is currently an impressive 94%!
https://coveralls.io/builds/8570591

It gives a report of the coverage on the CI with `coverage report`:
https://travis-ci.org/hugovk/Gutenberg/jobs/171618837#L211

And also sends the data to Coveralls, which is handy to track progress and show coverage of individual files:
https://coveralls.io/github/hugovk/Gutenberg

Please could an admin also enable Coveralls at https://coveralls.io/repos/new? It's free for open source :)

If you're developing locally, you can use `coverage html` to generate similar reports in htmlcov/index.html
