### PR TITLE
Fix load_etext for etexts 1-9

### DIFF
--- a/gutenberg/acquire/text.py
+++ b/gutenberg/acquire/text.py
@@ -19,6 +19,24 @@ from gutenberg._util.os import remove
 _TEXT_CACHE = local_path('text')
 
 
+def _etextno_to_uri_subdirectory(etextno):
+    """
+    For example, ebook #1 is in subdirectory:
+    0/1
+
+    And ebook #19 is in subdirectory:
+    1/19
+
+    While ebook #15453 is in this subdirectory:
+    1/5/4/5/15453
+    """
+    str_etextno = str(etextno).zfill(2)
+    all_but_last_digit = list(str_etextno[:-1])
+    subdir_part = "/".join(all_but_last_digit)
+    subdir = "{0}/{1}".format(subdir_part, etextno)  # etextno not zfilled
+    return subdir
+
+
 def _format_download_uri(etextno):
     """Returns the download location on the Project Gutenberg servers for a
     given text.
@@ -29,16 +47,12 @@ def _format_download_uri(etextno):
     """
     uri_root = r'http://www.gutenberg.lib.md.us'
     extensions = ('.txt', '-8.txt', '-0.txt')
-    str_etextno = str(etextno)
     for extension in extensions:
-        if etextno > 10:
-            path = '/'.join(str_etextno[:len(str_etextno) - 1])
-        else:
-            path = '0'
-        uri = '{root}/{path}/{etextno}/{etextno}{extension}'.format(
+        path = _etextno_to_uri_subdirectory(etextno)
+        uri = '{root}/{path}/{etextno}{extension}'.format(
             root=uri_root,
             path=path,
-            etextno=str_etextno,
+            etextno=etextno,
             extension=extension)
         response = requests.head(uri)
         if response.ok:

--- a/gutenberg/acquire/text.py
+++ b/gutenberg/acquire/text.py
@@ -28,37 +28,22 @@ def _format_download_uri(etextno):
 
     """
     uri_root = r'http://www.gutenberg.lib.md.us'
-
-    if 0 < etextno < 10:
-        oldstyle_files = (
-            'when11',
-            'bill11',
-            'jfk11',
-            'getty11',
-            'const11',
-            'liber11',
-            'mayfl11',
-            'linc211',
-            'linc111',
-        )
-        etextno = int(etextno)
-        return '{root}/etext90/{name}.txt'.format(
+    extensions = ('.txt', '-8.txt', '-0.txt')
+    str_etextno = str(etextno)
+    for extension in extensions:
+        if etextno > 10:
+            path = '/'.join(str_etextno[:len(str_etextno) - 1])
+        else:
+            path = '0'
+        uri = '{root}/{path}/{etextno}/{etextno}{extension}'.format(
             root=uri_root,
-            name=oldstyle_files[etextno - 1])
-
-    else:
-        etextno = str(etextno)
-        extensions = ('.txt', '-8.txt', '-0.txt')
-        for extension in extensions:
-            uri = '{root}/{path}/{etextno}/{etextno}{extension}'.format(
-                root=uri_root,
-                path='/'.join(etextno[:len(etextno) - 1]),
-                etextno=etextno,
-                extension=extension)
-            response = requests.head(uri)
-            if response.ok:
-                return uri
-        raise UnknownDownloadUriException
+            path=path,
+            etextno=str_etextno,
+            extension=extension)
+        response = requests.head(uri)
+        if response.ok:
+            return uri
+    raise UnknownDownloadUriException
 
 
 def load_etext(etextno, refresh_cache=False):


### PR DESCRIPTION
Precondition, no cached etext no. 1: 
```bash
rm ~/gutenberg_data/text/1.txt.gz
```

With this code:
```python
from gutenberg.acquire import load_etext
text = load_etext(1)
print(text)[:200]
```
Results in:
```html
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>404 Not Found</title>
</head><body>
<h1>Not Found</h1>
<p>The requested URL /etext90/when11.txt was not found on this server.</p>
```
With this PR, results in:
```txt


===========================================================

     NOTE:  This file combines the first two Project Gutenberg
     files, both of which were given the filenumber #1. There are


```
A similar thing happens for etexts 1-9.

Previously the URI for etexts 1-9 were special cases like:
http://www.gutenberg.lib.md.us/etext90/when11.txt

But now they're the like etexts>=10, like:
http://www.gutenberg.lib.md.us/0/1/1.txt
