### PR TITLE
Fix encoding issue reported in #62

### DIFF
--- a/gutenberg/acquire/text.py
+++ b/gutenberg/acquire/text.py
@@ -76,13 +76,11 @@ def load_etext(etextno, refresh_cache=False):
         makedirs(os.path.dirname(cached))
         download_uri = _format_download_uri(etextno)
         response = requests.get(download_uri)
-        response.encoding = 'utf-8'
         text = response.text
         with closing(gzip.open(cached, 'w')) as cache:
             cache.write(text.encode('utf-8'))
-    else:
-        with closing(gzip.open(cached, 'r')) as cache:
-            text = cache.read().decode('utf-8')
+    with closing(gzip.open(cached, 'r')) as cache:
+        text = cache.read().decode('utf-8')
     return text
 
 

--- a/gutenberg/acquire/text.py
+++ b/gutenberg/acquire/text.py
@@ -79,6 +79,7 @@ def load_etext(etextno, refresh_cache=False):
         text = response.text
         with closing(gzip.open(cached, 'w')) as cache:
             cache.write(text.encode('utf-8'))
+
     with closing(gzip.open(cached, 'r')) as cache:
         text = cache.read().decode('utf-8')
     return text

--- a/tests/test_acquire.py
+++ b/tests/test_acquire.py
@@ -42,6 +42,7 @@ class TestLoadEtext(MockTextMixin, unittest.TestCase):
         for testcase, loader in itertools.product(testcases, loaders):
             text = loader(testcase.etextno)
             self.assertIsInstance(text, str)
+            self.assertNotIn(u'\ufffd', text)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Removed the manual setting of `requests.encoding` and have `load_text` read from cache every time. Now it it able to load text of encoding other than utf-8.

Test case in issue #62 :
Running in shell 

> python -m gutenberg.acquire.text 2000 2000.txt

Before this patch:
> ......
>
> Yo, Juan Gallo de Andrada, escribano de C�mara del Rey nuestro se�or, de
> 
> los que residen en su Consejo, certifico y doy fe que, habiendo visto por
> 
> los se�ores d�l un libro intitulado El ingenioso hidalgo de la Mancha,
> 
> compuesto por Miguel de Cervantes Saavedra, tasaron cada pliego del dicho
> 
> libro a tres maraved�s y medio; el cual tiene ochenta y tres pliegos, que
> 
> al dicho precio monta el dicho libro docientos y noventa maraved�s y medio,
> 
> en que se ha de vender en papel; y dieron licencia para que a este precio
> 
> se pueda vender, y mandaron que esta tasa se ponga al principio del dicho
> 
> libro, y no se pueda vender sin ella. Y, para que dello conste, di la
> 
> presente en Valladolid, a veinte d�as del mes de deciembre de mil y
> 
> seiscientos y cuatro a�os.
>
> ......

Now:
>
> ......
> Yo, Juan Gallo de Andrada, escribano de Cámara del Rey nuestro señor, de
> 
> los que residen en su Consejo, certifico y doy fe que, habiendo visto por
> 
> los señores dél un libro intitulado El ingenioso hidalgo de la Mancha,
> 
> compuesto por Miguel de Cervantes Saavedra, tasaron cada pliego del dicho
> 
> libro a tres maravedís y medio; el cual tiene ochenta y tres pliegos, que
> 
> al dicho precio monta el dicho libro docientos y noventa maravedís y medio,
> 
> en que se ha de vender en papel; y dieron licencia para que a este precio
> 
> se pueda vender, y mandaron que esta tasa se ponga al principio del dicho
> 
> libro, y no se pueda vender sin ella. Y, para que dello conste, di la
> 
> presente en Valladolid, a veinte días del mes de deciembre de mil y
> 
> seiscientos y cuatro años.
> 
>......





