### PR TITLE
Prevent phantom metadata from crashing queries

### DIFF
--- a/gutenberg/query/api.py
+++ b/gutenberg/query/api.py
@@ -9,6 +9,7 @@ import os
 from six import with_metaclass
 from rdflib.term import URIRef
 
+from gutenberg._domain_model.exceptions import InvalidEtextIdException
 from gutenberg._domain_model.exceptions import UnsupportedFeatureException
 from gutenberg._domain_model.types import validate_etextno
 from gutenberg._util.abc import abstractclassmethod
@@ -114,7 +115,10 @@ class MetadataExtractor(with_metaclass(abc.ABCMeta, object)):
         meta-data RDF graph to a human-friendly integer text identifier.
 
         """
-        return validate_etextno(int(os.path.basename(uri_ref.toPython())))
+        try:
+            return validate_etextno(int(os.path.basename(uri_ref.toPython())))
+        except InvalidEtextIdException:
+            return None
 
     @staticmethod
     def __find_implementations():

--- a/gutenberg/query/extractors.py
+++ b/gutenberg/query/extractors.py
@@ -40,7 +40,8 @@ class _SimplePredicateRelationshipExtractor(MetadataExtractor):
     @classmethod
     def get_etexts(cls, requested_value):
         query = cls._metadata()[:cls.predicate():cls.contains(requested_value)]
-        return frozenset(cls._uri_to_etext(result) for result in query)
+        results = (cls._uri_to_etext(result) for result in query)
+        return frozenset(result for result in results if result is not None)
 
 
 class AuthorExtractor(_SimplePredicateRelationshipExtractor):

--- a/tests/_sample_metadata.py
+++ b/tests/_sample_metadata.py
@@ -12,7 +12,7 @@ import sys
 class SampleMetaData(object):
     __uids = {}
 
-    def __init__(self, etextno, authors=None, titles=None, formaturi=None, rights=None, subject=None, language=None):
+    def __init__(self, etextno, authors=None, titles=None, formaturi=None, rights=None, subject=None, language=None, is_phantom=False):
         self.author = frozenset(authors or [])
         self.title = frozenset(titles or [])
         self.formaturi = frozenset(formaturi or [])
@@ -22,6 +22,7 @@ class SampleMetaData(object):
         self.rights = frozenset(rights or [])
         self.subject = frozenset(subject or [])
         self.language = frozenset(language or [])
+        self.is_phantom = is_phantom
 
     @classmethod
     def __create_uid(cls, hashable):

--- a/tests/_sample_metadata.py
+++ b/tests/_sample_metadata.py
@@ -16,7 +16,9 @@ class SampleMetaData(object):
         self.author = frozenset(authors or [])
         self.title = frozenset(titles or [])
         self.formaturi = frozenset(formaturi or [])
-        self.etextno = etextno or self.__create_uid(self.author | self.title)
+        self.etextno = (etextno
+                        if etextno is not None
+                        else self.__create_uid(self.author | self.title))
         self.rights = frozenset(rights or [])
         self.subject = frozenset(subject or [])
         self.language = frozenset(language or [])

--- a/tests/data/sample-metadata/0
+++ b/tests/data/sample-metadata/0
@@ -1,0 +1,5 @@
+{
+    "is_phantom": true,
+    "language": ["en"],
+    "rights": ["Public domain in the USA."]
+}

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -58,16 +58,19 @@ class TestGetEtexts(MockMetadataMixin, unittest.TestCase):
         for testcase in self.sample_data():
             for feature_value in getattr(testcase, feature):
                 actual = get_etexts(feature, feature_value)
-                self.assertIn(
-                    testcase.etextno,
-                    actual,
-                    "didn't retrieve {etextno} when querying for books that "
-                    'have {feature}="{feature_value}" (got {actual}).'
-                    .format(
-                        etextno=testcase.etextno,
-                        feature=feature,
-                        feature_value=feature_value,
-                        actual=actual))
+                if testcase.is_phantom:
+                    self.assertNotIn(testcase.etextno, actual)
+                else:
+                    self.assertIn(
+                        testcase.etextno,
+                        actual,
+                        "didn't retrieve {etextno} when querying for books "
+                        'that have {feature}="{feature_value}" (got {actual}).'
+                        .format(
+                            etextno=testcase.etextno,
+                            feature=feature,
+                            feature_value=feature_value,
+                            actual=actual))
 
     def test_get_etexts_title(self):
         self._run_get_etexts_for_feature('title')


### PR DESCRIPTION
This is a partial fix for the [issue](https://github.com/c-w/Gutenberg/issues/57#issuecomment-262246622) reported by @ikarth on #57.