### PR TITLE
Change mirrors and make it easier for end users to switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.pyc
 /virtualenv/
+/venv/
 /dist/
+/build/
 /*.egg-info
 /.idea/
 .coverage

--- a/gutenberg/_util/decorators.py
+++ b/gutenberg/_util/decorators.py
@@ -1,0 +1,13 @@
+"""Module to deal with decorators"""
+
+
+def execute_only_once(func):
+    """Decorator that will only allow a function to be executed the first time it's called"""
+    def call_once(*args, **kwargs):
+        if not call_once._called:
+            try:
+                return func(*args, **kwargs)
+            finally:
+                call_once._called = True
+    call_once._called = False
+    return call_once

--- a/gutenberg/acquire/text.py
+++ b/gutenberg/acquire/text.py
@@ -57,9 +57,9 @@ def _format_download_uri(etextno, mirror=None):
     if _MIRROR_CHECK is None:
         response = requests.head(uri_root)
         if not response.ok:
-            error = "Could not reach gutenberg mirror. Try setting a different mirror " \
-                    "(https://www.gutenberg.org/MIRRORS.ALL) for GUTENBERG_MIRROR environment " \
-                    "variable."
+            error = "Could not reach Gutenberg mirror '{:s}'. Try setting a different mirror " \
+                    "(https://www.gutenberg.org/MIRRORS.ALL) for --mirror flag or " \
+                    "GUTENBERG_MIRROR environment variable.".format(uri_root)
             raise UnknownDownloadUriException(error)
         _MIRROR_CHECK = True
 

--- a/gutenberg/acquire/text.py
+++ b/gutenberg/acquire/text.py
@@ -53,7 +53,7 @@ def _format_download_uri(etextno, mirror=None):
         uri_root = _GUTENBERG_MIRROR
     else:
         uri_root = mirror
-    uri_root = uri_root.rstrip("/")
+    uri_root = uri_root.strip().rstrip("/")
     if _MIRROR_CHECK is None:
         response = requests.head(uri_root)
         if not response.ok:

--- a/gutenberg/acquire/text.py
+++ b/gutenberg/acquire/text.py
@@ -44,8 +44,8 @@ def _etextno_to_uri_subdirectory(etextno):
 @execute_only_once
 def _check_mirror_exists(mirror):
     response = requests.head(mirror)
-    if not response.ok:
-        error = "Could not reach Gutenberg mirror '{:s}'. Try setting a different mirror " \
+    if response.ok:
+        error = "Could not reach Gutenberg mirror '{0:s}'. Try setting a different mirror " \
                 "(https://www.gutenberg.org/MIRRORS.ALL) for --mirror flag or " \
                 "GUTENBERG_MIRROR environment variable.".format(mirror)
         raise UnknownDownloadUriException(error)
@@ -58,8 +58,9 @@ def _format_download_uri(etextno, mirror=None):
     Raises:
         UnknownDownloadUri: If no download location can be found for the text.
     """
-    uri_root = _GUTENBERG_MIRROR if mirror is None else mirror
+    uri_root = mirror or _GUTENBERG_MIRROR
     uri_root = uri_root.strip().rstrip('/')
+    print(uri_root)
     _check_mirror_exists(uri_root)
 
     extensions = ('.txt', '-8.txt', '-0.txt')

--- a/gutenberg/acquire/text.py
+++ b/gutenberg/acquire/text.py
@@ -73,7 +73,6 @@ def _format_download_uri(etextno, mirror=None):
             extension=extension)
         response = requests.head(uri)
         if response.ok:
-            print(uri)
             return uri
     raise UnknownDownloadUriException("Failed to find {} on {}.".format(etextno, uri_root))
 
@@ -124,7 +123,7 @@ def _main():
         mirror = None
 
     try:
-        text = load_etext(args.etextno, True, mirror=mirror)
+        text = load_etext(args.etextno, mirror=mirror)
         with reopen_encoded(args.outfile, 'w', 'utf8') as outfile:
             outfile.write(text)
     except Error as error:

--- a/gutenberg/acquire/text.py
+++ b/gutenberg/acquire/text.py
@@ -44,7 +44,7 @@ def _etextno_to_uri_subdirectory(etextno):
 @execute_only_once
 def _check_mirror_exists(mirror):
     response = requests.head(mirror)
-    if response.ok:
+    if not response.ok:
         error = "Could not reach Gutenberg mirror '{0:s}'. Try setting a different mirror " \
                 "(https://www.gutenberg.org/MIRRORS.ALL) for --mirror flag or " \
                 "GUTENBERG_MIRROR environment variable.".format(mirror)
@@ -60,7 +60,6 @@ def _format_download_uri(etextno, mirror=None):
     """
     uri_root = mirror or _GUTENBERG_MIRROR
     uri_root = uri_root.strip().rstrip('/')
-    print(uri_root)
     _check_mirror_exists(uri_root)
 
     extensions = ('.txt', '-8.txt', '-0.txt')


### PR DESCRIPTION
Closes #81

General usage for allowing the end user to specify a mirror to use:
```
$ python3 -m gutenberg.acquire.text 2701 moby-raw.txt
INFO:rdflib:RDFLib Version: 4.2.2
http://aleph.gutenberg.org/2/7/0/2701/2701.txt

$ python3 -m gutenberg.acquire.text --mirror http://mirrors.xmission.com/gutenberg/ 2701 moby-raw.txt
INFO:rdflib:RDFLib Version: 4.2.2
http://mirrors.xmission.com/gutenberg/2/7/0/2701/2701.txt

$ GUTENBERG_MIRROR=http://mirrors.xmission.com/gutenberg/ python3 -m gutenberg.acquire.text 2701 moby-raw.txt
INFO:rdflib:RDFLib Version: 4.2.2
http://mirrors.xmission.com/gutenberg/2/7/0/2701/2701.txt

$ GUTENBERG_MIRROR=http://mirrors.xmission.com/gutenberg/ python3 -m gutenberg.acquire.text --mirror http://eremita.di.uminho.pt/gutenberg/ 2701 moby-raw.txt
INFO:rdflib:RDFLib Version: 4.2.2
http://eremita.di.uminho.pt/gutenberg/2/7/0/2701/2701.txt
```
(the printed URI is just for the example, won't happen in real usage)

I've also added an additional exception in using an invalid mirror (ie, URI doesn't exist, forbidden, etc):
```
python3 -m gutenberg.acquire.text --mirror http://www.gutenberg.lib.md.us 2701 moby-raw.txtINFO:rdflib:RDFLib Version: 4.2.2
usage: text.py [-h] [--mirror MIRROR] etextno outfile
text.py: error: Could not reach Gutenberg mirror 'http://www.gutenberg.lib.md.us'. Try setting a different mirror (https://www.gutenberg.org/MIRRORS.ALL) for --mirror flag or GUTENBERG_MIRROR environment variable.
```

And if you use a good mirror, but the etext does not exist (this will return an empty message in current version):
```
python3 -m gutenberg.acquire.text 270111111111 moby-raw.txt                                                                                                  [10:14:10]
INFO:rdflib:RDFLib Version: 4.2.2
usage: text.py [-h] [--mirror MIRROR] etextno outfile
text.py: error: Failed to find 270111111111 on http://aleph.gutenberg.org.
```