### PR TITLE
Add integration test for load_etext

### DIFF
--- a/tests/_sample_metadata.py
+++ b/tests/_sample_metadata.py
@@ -133,4 +133,5 @@ def _sample_metadata_path():
 
 def _load_metadata(etextno):
     data_path = os.path.join(_sample_metadata_path(), str(etextno))
-    return json.load(open(data_path))
+    with open(data_path) as fobj:
+        return json.load(fobj)

--- a/tests/_util.py
+++ b/tests/_util.py
@@ -7,6 +7,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import abc
+import os
 import shutil
 import sys
 import tempfile
@@ -24,6 +25,9 @@ if sys.version_info < (2, 7):
 else:
     import unittest
 assert unittest  # silence warning
+
+
+INTEGRATION_TESTS_ENABLED = bool(os.getenv('GUTENBERG_RUN_INTEGRATION_TESTS'))
 
 
 # noinspection PyPep8Naming,PyAttributeOutsideInit

--- a/tests/test_acquire.py
+++ b/tests/test_acquire.py
@@ -12,6 +12,7 @@ from gutenberg._domain_model.exceptions import UnknownDownloadUriException
 from gutenberg._domain_model.vocabulary import DCTERMS
 from gutenberg._domain_model.vocabulary import PGTERMS
 from tests._sample_metadata import SampleMetaData
+from tests._util import INTEGRATION_TESTS_ENABLED
 from tests._util import MockMetadataMixin
 from tests._util import MockTextMixin
 from tests._util import unittest
@@ -50,6 +51,14 @@ class TestLoadEtext(MockTextMixin, unittest.TestCase):
     def test_invalid_etext(self):
         with self.assertRaises(UnknownDownloadUriException):
             text.load_etext(1, mirror='http://example.com')
+
+
+@unittest.skipUnless(INTEGRATION_TESTS_ENABLED, reason='unit-tests only')
+class TestLoadEtextNetworked(unittest.TestCase):
+    def test_load_etext(self):
+        etext = text.load_etext(2701)
+        self.assertIsInstance(etext, str)
+        self.assertGreater(len(etext), 1000)
 
 
 class TestFailLoadEtext(unittest.TestCase):

--- a/tests/test_acquire.py
+++ b/tests/test_acquire.py
@@ -43,9 +43,9 @@ class TestLoadEtext(MockTextMixin, unittest.TestCase):
             SampleMetaData.for_etextno(23962)   # UTF-8 text
         )
         for testcase, loader in itertools.product(testcases, loaders):
-            text = loader(testcase.etextno)
-            self.assertIsInstance(text, str)
-            self.assertNotIn(u'\ufffd', text)
+            etext = loader(testcase.etextno)
+            self.assertIsInstance(etext, str)
+            self.assertNotIn(u'\ufffd', etext)
 
     def test_invalid_etext(self):
         with self.assertRaises(UnknownDownloadUriException):


### PR DESCRIPTION
We can run this test every day via the [Travis cron feature](https://docs.travis-ci.com/user/cron-jobs/) to alert us to changes in the environment that may change the mirror we're using for the texts and prevent issues like #81 affecting our users in the future.

Also: some minor test cleanups.
