### PR TITLE
Add link to http API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,8 @@ The functionality provided by this package includes:
 
 The package has been tested with Python 2.6, 2.7, 3.3, 3.4, 3.5 and 3.6.
 
+A hosted version of this package exists too. `Try it out! <https://c-w.github.io/gutenberg-http/>`_
+
 
 Installation
 ============


### PR DESCRIPTION
This package isn't the easiest to set up: getting BSD-DB installed is finicky, building the metadata store takes a long time and takes up a lot of disk space, etc.

To remedy this, I set up a hosted version of the library: [gutenberg-http](https://github.com/c-w/gutenberg-http) ([demo page](https://c-w.github.io/gutenberg-http/)).
 
Mentioning all the core-contributors @hugovk @MasterOdin @sethwoodworth in case you'd like to take a look and maybe help out :)