### PR TITLE
Remove unsupported Python 2.6 and 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ dist: trusty
 language: python
 cache: pip
 python:
-  - '2.6'
   - '2.7'
-  - '3.3'
   - '3.4'
   - '3.5'
   - '3.6'
@@ -18,14 +16,13 @@ before_install:
 
 install:
   - pip install -U setuptools
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install unittest2; fi
   - pip install -r requirements.pip
   - pip install -r requirements-py3.pip
   - pip install -r requirements-dev.pip
 
 script:
   - coverage run --source=gutenberg -m nose
-  - if [[ $TRAVIS_PYTHON_VERSION != 2.6 ]]; then flake8 gutenberg; fi
+  - flake8 gutenberg
 
 after_success:
   - coverage report

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ The functionality provided by this package includes:
 * Cleaning the texts: removing all the crud, leaving just the text behind.
 * Making meta-data about the texts easily accessible.
 
-The package has been tested with Python 2.6, 2.7, 3.3, 3.4, 3.5 and 3.6.
+The package has been tested with Python 2.7, 3.4, 3.5 and 3.6.
 
 A hosted version of this package exists too. `Try it out! <https://c-w.github.io/gutenberg-http/>`_
 

--- a/tests/_sample_metadata.py
+++ b/tests/_sample_metadata.py
@@ -12,7 +12,8 @@ import sys
 class SampleMetaData(object):
     __uids = {}
 
-    def __init__(self, etextno, authors=None, titles=None, formaturi=None, rights=None, subject=None, language=None, is_phantom=False):
+    def __init__(self, etextno, authors=None, titles=None, formaturi=None,
+                 rights=None, subject=None, language=None, is_phantom=False):
         self.author = frozenset(authors or [])
         self.title = frozenset(titles or [])
         self.formaturi = frozenset(formaturi or [])
@@ -62,9 +63,9 @@ class SampleMetaData(object):
     def _rdf_rights(self):
         return '' if not self.rights else '\n'.join(
             '<http://www.gutenberg.org/ebooks/{etextno}> '
-             '<http://purl.org/dc/terms/rights> '
+            '<http://purl.org/dc/terms/rights> '
             '"{rights}"'
-             '.'
+            '.'
             .format(etextno=self.etextno, rights=rights)
             for rights in self.rights)
 

--- a/tests/_util.py
+++ b/tests/_util.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import, unicode_literals
 import abc
 import os
 import shutil
-import sys
 import tempfile
 from contextlib import closing
 from contextlib import contextmanager
@@ -20,10 +19,7 @@ from gutenberg.acquire.metadata import SleepycatMetadataCache
 from gutenberg.acquire.metadata import set_metadata_cache
 import gutenberg.acquire.text
 
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 assert unittest  # silence warning
 
 

--- a/tests/_util.py
+++ b/tests/_util.py
@@ -19,9 +19,6 @@ from gutenberg.acquire.metadata import SleepycatMetadataCache
 from gutenberg.acquire.metadata import set_metadata_cache
 import gutenberg.acquire.text
 
-import unittest
-assert unittest  # silence warning
-
 
 INTEGRATION_TESTS_ENABLED = bool(os.getenv('GUTENBERG_RUN_INTEGRATION_TESTS'))
 

--- a/tests/test_acquire.py
+++ b/tests/test_acquire.py
@@ -5,8 +5,9 @@
 
 from __future__ import absolute_import, unicode_literals
 from builtins import str
-import itertools
 from collections import namedtuple
+import itertools
+import unittest
 
 from gutenberg._domain_model.exceptions import UnknownDownloadUriException
 from gutenberg._domain_model.vocabulary import DCTERMS
@@ -15,7 +16,6 @@ from tests._sample_metadata import SampleMetaData
 from tests._util import INTEGRATION_TESTS_ENABLED
 from tests._util import MockMetadataMixin
 from tests._util import MockTextMixin
-from tests._util import unittest
 
 from gutenberg.acquire import text
 from gutenberg.acquire import load_etext

--- a/tests/test_domain_model.py
+++ b/tests/test_domain_model.py
@@ -3,10 +3,10 @@
 
 
 from __future__ import absolute_import, unicode_literals
+import unittest
 
 from gutenberg._domain_model.exceptions import InvalidEtextIdException
 from gutenberg._domain_model.types import validate_etextno
-from tests._util import unittest
 
 
 class TestValidateEtextno(unittest.TestCase):

--- a/tests/test_metadata_cache.py
+++ b/tests/test_metadata_cache.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, unicode_literals
 import os
 import sys
 import tempfile
+import unittest
 
 from gutenberg._util.url import pathname2url
 from gutenberg.acquire.metadata import CacheAlreadyExistsException
@@ -16,7 +17,6 @@ from gutenberg.acquire.metadata import SqliteMetadataCache
 from gutenberg.acquire.metadata import set_metadata_cache
 from gutenberg.query import get_metadata
 from tests._util import always_throw
-from tests._util import unittest
 
 
 # noinspection PyPep8Naming,PyAttributeOutsideInit

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -3,6 +3,7 @@
 
 
 from __future__ import absolute_import, unicode_literals
+import unittest
 
 from tests._sample_metadata import SampleMetaData
 from tests._util import MockMetadataMixin
@@ -10,7 +11,6 @@ from tests._util import MockMetadataMixin
 from gutenberg.query import get_etexts
 from gutenberg.query import get_metadata
 from gutenberg.query import list_supported_metadatas
-from tests._util import unittest
 
 
 class TestListSupportedMetadatas(unittest.TestCase):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -97,5 +97,6 @@ class TestGetEtexts(MockMetadataMixin, unittest.TestCase):
     def test_get_etexts_subject(self):
         self._run_get_etexts_for_feature('subject')
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_strip_headers.py
+++ b/tests/test_strip_headers.py
@@ -41,14 +41,14 @@ def _previous_lines(i, lines, amount):
     lower = max(0, i-amount)
     prev_lines = lines[lower:i-1]
     return '\n'.join('line {0}: "{1}"'.format(j, line)
-                        for j, (_, line) in enumerate(prev_lines, start=lower))
+                     for j, (_, line) in enumerate(prev_lines, start=lower))
 
 
 def _next_lines(i, lines, amount):
     upper = min(len(lines), i+amount+1)
     next_lines = lines[i+1:upper]
     return '\n'.join('line {0}: "{1}"'.format(j, line)
-                        for j, (_, line) in enumerate(next_lines, start=i+1))
+                     for j, (_, line) in enumerate(next_lines, start=i+1))
 
 
 if __name__ == '__main__':

--- a/tests/test_strip_headers.py
+++ b/tests/test_strip_headers.py
@@ -3,9 +3,9 @@
 
 
 from __future__ import absolute_import, unicode_literals
+import unittest
 
 from tests._sample_text import SampleText
-from tests._util import unittest
 
 from gutenberg.cleanup import strip_headers
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -47,7 +47,8 @@ class TestAllSubclasses(unittest.TestCase):
 
 class TestAbstractClassMethod(unittest.TestCase):
     def test_abstractclassmethod(self):
-        class ClassWithAbstractClassMethod(with_metaclass(abc.ABCMeta, object)):
+        class ClassWithAbstractClassMethod(
+                with_metaclass(abc.ABCMeta, object)):
             @abstractclassmethod
             def method(cls):
                 pass

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -9,6 +9,7 @@ import codecs
 import os
 import shutil
 import tempfile
+import unittest
 
 from six import with_metaclass
 
@@ -18,7 +19,6 @@ from gutenberg._util.os import makedirs
 from gutenberg._util.os import remove
 from gutenberg._util.os import reopen_encoded
 from tests._util import always_throw
-from tests._util import unittest
 
 
 class TestAllSubclasses(unittest.TestCase):


### PR DESCRIPTION
## Reasons for dropping old ones

* https://en.wikipedia.org/wiki/CPython#Version_history

### 2.6

* https://snarky.ca/stop-using-python-2-6/
* http://www.curiousefficiency.org/posts/2015/04/stop-supporting-python26.html
* Current pip 9 deprecates Python 2.6 support, pip 10 won't support it (https://github.com/pypa/pip/issues/3955)
* Not much PyPI traffic (June 2016) https://github.com/pypa/pip/issues/3796

### 3.3

* pip 10 will deprecate Python 3.3 support, pip 11 won't support it (https://github.com/pypa/pip/issues/3796)
* Very little PyPI traffic (June 2016) https://github.com/pypa/pip/issues/3796
