### PR TITLE
setuptools >38 needs install_requires to be a list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.idea/
 .coverage
 htmlcov/
+.DS_Store

--- a/setup.py
+++ b/setup.py
@@ -49,4 +49,4 @@ setup(
     description='Library to interface with Project Gutenberg',
     long_description=open('README.rst').read(),
     dependency_links=dependency_links,
-    install_requires=install_requires)
+    install_requires=list(install_requires))

--- a/setup.py
+++ b/setup.py
@@ -49,4 +49,4 @@ setup(
     description='Library to interface with Project Gutenberg',
     long_description=open('README.rst').read(),
     dependency_links=dependency_links,
-    install_requires=list(install_requires))
+    install_requires=sorted(install_requires))

--- a/setup.py
+++ b/setup.py
@@ -39,14 +39,24 @@ dependency_links = links_general | links_version
 
 setup(
     name='Gutenberg',
-    version='0.5.0',
+    version='0.6.0',
     author='Clemens Wolff',
     author_email='clemens.wolff+pypi@gmail.com',
     packages=find_packages(exclude=['tests']),
     url='https://github.com/c-w/Gutenberg',
-    download_url='http://pypi.python.org/pypi/Gutenberg',
-    license='License :: OSI Approved :: Apache Software License',
+    download_url='https://pypi.python.org/pypi/Gutenberg',
+    license='Apache Software License',
     description='Library to interface with Project Gutenberg',
     long_description=open('README.rst').read(),
     dependency_links=dependency_links,
-    install_requires=sorted(install_requires))
+    install_requires=sorted(install_requires),
+    python_requires='==2.7.*,>=3.4',
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Topic :: Utilities'
+    ])


### PR DESCRIPTION
setuptools 38.0 made it so that install_requires must be an ordered sequence (so that they can do deterministic builds): https://github.com/pypa/setuptools/blob/master/CHANGES.rst#v3800. We are currently declaring them as sets so therefore the package will break on PyPI for anyone using the newest versions of setuptools.

After this is merged, we should also then bump up the version (to 0.5.1?) so that we get a fix on PyPI for people and which would then also incidently fix python 3.6 testing for c-w/gutenberg-http#3 to be merged. The only real change that's occurred since last release was removing support for Python 2.6 and 3.3.
  