### PR TITLE
Move from coveralls to codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,10 @@ install:
 
 script:
   - docker run -v $PWD:/app --tmpfs /data "gutenberg-$TRAVIS_PYTHON_VERSION" flake8 gutenberg
-  - docker run -v $PWD:/app --tmpfs /data "gutenberg-$TRAVIS_PYTHON_VERSION" coverage run --source=gutenberg -m nose2
+  - docker run -v $PWD:/app --tmpfs /data "gutenberg-$TRAVIS_PYTHON_VERSION" nose2 --with-coverage
 
 after_success:
-  - coverage report
-  - pip install coveralls
-  - coveralls
+  - pip install codecov && codecov
 
 deploy:
   provider: pypi

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,10 @@ Gutenberg
 
 .. image:: https://travis-ci.org/c-w/gutenberg.svg?branch=master
     :target: https://travis-ci.org/c-w/gutenberg
-.. image:: https://coveralls.io/repos/github/c-w/Gutenberg/badge.svg?branch=master
-    :target: https://coveralls.io/github/c-w/Gutenberg?branch=master
+
+.. image:: https://codecov.io/gh/c-w/gutenberg/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/c-w/gutenberg
+
 .. image:: https://img.shields.io/pypi/v/gutenberg.svg
     :target: https://pypi.python.org/pypi/gutenberg/
 


### PR DESCRIPTION
The Travis logs show that the coveralls repo seems to have disappeared (error: "Couldn't find a repository matching this job.") so this change is moving the project from coveralls to codecov.