### PR TITLE
Switch to using build matrix for python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: python
 
-python:
-  - '2.7'
-  - '3.4'
-  - '3.5'
-  - '3.6'
+python: 3.6
+
+env:
+  - DOCKER_PYTHON_VERSION=2.7
+  - DOCKER_PYTHON_VERSION=3.4
+  - DOCKER_PYTHON_VERSION=3.5
+  - DOCKER_PYTHON_VERSION=3.6
+  - DOCKER_PYTHON_VERSION=3.7
 
 services:
   - docker
@@ -14,12 +17,12 @@ before_install:
   - docker run --detach --name fuseki --network gutenberg --tmpfs /fuseki --env ADMIN_PASSWORD=some-password stain/jena-fuseki:3.6.0 /jena-fuseki/fuseki-server --loc=/fuseki --update /ds
 
 install:
-  - if [ "$TRAVIS_PYTHON_VERSION" = "2.7" ]; then docker build --build-arg PYTHON_VERSION="$TRAVIS_PYTHON_VERSION" -t "gutenberg-$TRAVIS_PYTHON_VERSION" -f Dockerfile-py2 .; fi
-  - if [ "$TRAVIS_PYTHON_VERSION" != "2.7" ]; then docker build --build-arg PYTHON_VERSION="$TRAVIS_PYTHON_VERSION" -t "gutenberg-$TRAVIS_PYTHON_VERSION" -f Dockerfile-py3 .; fi
+  - if [ "$DOCKER_PYTHON_VERSION" = "2.7" ]; then docker build --build-arg PYTHON_VERSION="$DOCKER_PYTHON_VERSION" -t "gutenberg-$DOCKER_PYTHON_VERSION" -f Dockerfile-py2 .; fi
+  - if [ "$DOCKER_PYTHON_VERSION" != "2.7" ]; then docker build --build-arg PYTHON_VERSION="$DOCKER_PYTHON_VERSION" -t "gutenberg-$DOCKER_PYTHON_VERSION" -f Dockerfile-py3 .; fi
 
 script:
-  - docker run -v $PWD:/app --tmpfs /data "gutenberg-$TRAVIS_PYTHON_VERSION" flake8 gutenberg
-  - docker run -v $PWD:/app --tmpfs /data --network gutenberg --env UNIT_TEST_GUTENBERG_FUSEKI_URL=http://fuseki:3030/ds --env GUTENBERG_FUSEKI_USER=admin --env GUTENBERG_FUSEKI_PASSWORD=some-password "gutenberg-$TRAVIS_PYTHON_VERSION" nose2 --verbose --with-coverage
+  - docker run -v $PWD:/app --tmpfs /data "gutenberg-$DOCKER_PYTHON_VERSION" flake8 gutenberg
+  - docker run -v $PWD:/app --tmpfs /data --network gutenberg --env UNIT_TEST_GUTENBERG_FUSEKI_URL=http://fuseki:3030/ds --env GUTENBERG_FUSEKI_USER=admin --env GUTENBERG_FUSEKI_PASSWORD=some-password "gutenberg-$DOCKER_PYTHON_VERSION" nose2 --verbose --with-coverage
 
 after_success:
   - pip install codecov && codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ script:
   - docker run -v $PWD:/app --tmpfs /data --network gutenberg --env UNIT_TEST_GUTENBERG_FUSEKI_URL=http://fuseki:3030/ds --env GUTENBERG_FUSEKI_USER=admin --env GUTENBERG_FUSEKI_PASSWORD=some-password "gutenberg-$DOCKER_PYTHON_VERSION" nose2 --verbose --with-coverage
 
 after_success:
+  # Overwrite variable for codecov
+  - export TRAVIS_PYTHON_VERSION=${DOCKER_PYTHON_VERSION}
   - pip install codecov && codecov
 
 deploy:


### PR DESCRIPTION
I noticed that yesterday that Travis failed unusually only Python 3.4 and then 2.7 in a subsequent build in their build environment. However, we don't really need the Python version itself as everything is done within containers.

This also better handles the future where it's unlikely that Python 3.7 will be supported on Travis for Trusty and Python 3.4 won't be supported on Xenial/Bionic, both of which we want to support in gutenberg for the time being.