### PR TITLE
Updating encoding for file open

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, unicode_literals
 from os.path import isfile
 from sys import version_info
+import codecs
 
 from setuptools import find_packages
 from setuptools import setup
@@ -36,10 +37,9 @@ requirements_general, links_general = requirements_for()
 requirements_version, links_version = requirements_for(version_info.major)
 install_requires = requirements_general | requirements_version
 dependency_links = links_general | links_version
-if version_info.major >=3:
-    long_description = open('README.rst', encoding="utf-8").read()
-else:
-    long_description = open('README.rst').read()
+
+with codecs.open('README.rst', encoding='utf-8') as fobj:
+    long_description = fobj.read()
 
 setup(
     name='Gutenberg',

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,10 @@ requirements_general, links_general = requirements_for()
 requirements_version, links_version = requirements_for(version_info.major)
 install_requires = requirements_general | requirements_version
 dependency_links = links_general | links_version
+if version_info.major >=3:
+    long_description = open('README.rst', encoding="utf-8").read()
+else:
+    long_description = open('README.rst').read()
 
 setup(
     name='Gutenberg',
@@ -47,7 +51,7 @@ setup(
     download_url='https://pypi.python.org/pypi/Gutenberg',
     license='Apache Software License',
     description='Library to interface with Project Gutenberg',
-    long_description=open('README.rst').read(),
+    long_description=long_description,
     dependency_links=dependency_links,
     install_requires=sorted(install_requires),
     python_requires='>=2.7.*,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',


### PR DESCRIPTION
If the file encoding on your system (Linux, Windows, etc) is not set to utf-8, this line could cause problems when reading non-ascii characters from the Readme. This simplifies the `open()` statement so that the pip installation is less dependent on system variables.