### PR TITLE
Changed linux install from libdb5.1-dev to libdb++-dev

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ manager. For example, on Ubuntu, you can use apt-get:
 
 .. sourcecode :: sh
 
-    sudo apt-get install libdb5.1-dev
+    sudo apt-get install libdb++-dev
     export BERKELEYDB_DIR=/usr
     pip install -r requirements-py3.pip
 


### PR DESCRIPTION
Libdb5.1-dev is not available for Ubuntu 16.04. libdb++-dev works in its place for this project.