### PR TITLE
Fix multiple deploys to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-language: python
-
-python: 3.6
+language: minimal
 
 env:
   - DOCKER_PYTHON_VERSION=2.7
@@ -33,3 +31,4 @@ deploy:
     tags: true
     distributions: sdist bdist_wheel
     repo: c-w/gutenberg
+    condition: $DOCKER_PYTHON_VERSION = 3.7


### PR DESCRIPTION
When releasing a new version, the current Travis configuration attempts to deploy the code to PyPI for every Python version. PyPI releases are now immutable so the build's behavior causes errors (see [sample build](https://travis-ci.org/c-w/gutenberg/builds/576317320). Gating the PyPI upload to a single Python version fixes this behavior.