### PR TITLE
Add upper version limit for rdflib

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,12 +58,20 @@ steps:
   displayName: 'Upgrade pip and setuptools'
 
 - powershell: |
-    $mirror = "https://download.lfd.uci.edu/pythonlibs/r7aykn4w"
+    $mirror = "https://download.lfd.uci.edu/pythonlibs/s2jqpv5t/cp3$(python.version.minor)"
     $wheel = "bsddb3-6.2.6-cp3$(python.version.minor)-cp3$(python.version.minor)m-win_amd64.whl"
     Invoke-WebRequest -Uri "$mirror/$wheel" -OutFile "$(Agent.TempDirectory)\$wheel"
     pip install "$(Agent.TempDirectory)\$wheel"
-  condition: and(eq(variables['python.version.major'], '3'), eq(variables['os.image'], 'windows-latest'))
-  displayName: 'Install bsddb3 wheel'
+  condition: and(eq(variables['python.version.major'], '3'), eq(variables['os.image'], 'windows-latest'), eq(variables['python.version.minor'], '5'))
+  displayName: 'Install bsddb3 wheel (3.5)'
+
+- powershell: |
+    $mirror = "https://download.lfd.uci.edu/pythonlibs/s2jqpv5t"
+    $wheel = "bsddb3-6.2.7-cp3$(python.version.minor)-cp3$(python.version.minor)m-win_amd64.whl"
+    Invoke-WebRequest -Uri "$mirror/$wheel" -OutFile "$(Agent.TempDirectory)\$wheel"
+    pip install "$(Agent.TempDirectory)\$wheel"
+  condition: and(eq(variables['python.version.major'], '3'), eq(variables['os.image'], 'windows-latest'), ge(variables['python.version.minor'], '6'))
+  displayName: 'Install bsddb3 wheel (3.6+)'
 
 - script: |
     brew install berkeley-db4

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 
 install_requires = [
     'future>=0.15.2',
-    'rdflib>=4.2.0',
+    'rdflib>=4.2.0,<5.0.0',
     'requests>=2.5.1',
     'six>=1.10.0',
     'setuptools>=18.5',


### PR DESCRIPTION
rdflib 5.0.0 reworked some amount of their interface, which breaks things here. Minimally, SPARQLWrapper is no longer used, and a requests based wrapper internal to rdflib is now used, which breaks compatibility with older RDF stores that do not follow the SPARQL Protocol 1.1 spec. Setting this to minimize the break here, with a look to move to rdflib 5 in the next major version bump of gutenberg itself.