### PR TITLE
Fix install on MacOS with Python 2.7

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,9 @@
-# .coveragerc to control coverage.py
+[run]
+omit =
+    # Don't complain about installer code
+    setup.py
 
 [report]
-# Regexes for lines to exclude from consideration
 exclude_lines =
     # Have to re-enable the standard pragma:
     pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,11 @@ if version_info.major == 2:
         'functools32>=3.2.3-2',
     ])
 
-if version_info.major == 3 or system() == 'Darwin':
+if version_info.major == 2 and system() == 'Darwin':
+    install_requires.extend([
+        'bsddb3>=6.1.0,<6.2.8',
+    ])
+elif version_info.major == 3 or system() == 'Darwin':
     install_requires.extend([
         'bsddb3>=6.1.0',
     ])


### PR DESCRIPTION
The CI on MacOS and Python 2.7 started failing when bsddb 6.2.8 was released (see [failed build log](https://clewolff.visualstudio.com/gutenberg/_build/results?buildId=1410&view=logs&j=5f8b5a4a-0b9d-5350-fd1f-b70854064a4e&t=e1dbd89e-54a5-5e77-0e95-3a01560a81d2) and [failed build screenshot](https://user-images.githubusercontent.com/1086421/99916244-f92c8500-2cd6-11eb-9496-c03eaa55eb76.png)).

Given that Python 2.7 is deprecated, this pull request works around the issue by pinning bsddb to 6.2.7 or earlier for the affected combination of OS and Python version (see [successful build log](https://clewolff.visualstudio.com/gutenberg/_build/results?buildId=1411&view=logs&j=5f8b5a4a-0b9d-5350-fd1f-b70854064a4e&t=e1dbd89e-54a5-5e77-0e95-3a01560a81d2)).